### PR TITLE
Fix deprecation warnings surfacing in hera CI (refs hera#971)

### DIFF
--- a/hermes/taskwrapper/wrapper.py
+++ b/hermes/taskwrapper/wrapper.py
@@ -85,7 +85,7 @@ t
 
     @classmethod
     def parsePath(cls, parameter):
-        """
+        r"""
             Determine which parts of the input are path to parse and which
             stay as they are.
 

--- a/hermes/utils/logging/helpers.py
+++ b/hermes/utils/logging/helpers.py
@@ -3,7 +3,7 @@ import logging
 import logging.config
 import os.path
 import pathlib
-from importlib.resources import read_text
+from importlib.resources import files
 
 HERMES_DEFAULT_LOG_DIR = pathlib.Path.home() / ".pyhermes" / "log"
 
@@ -28,7 +28,7 @@ def get_classMethod_logger(instance, name=None):
 def get_default_logging_config(*, disable_existing_loggers: bool = False) -> dict:
     defaultLocalConfig = os.path.join(HERMES_DEFAULT_LOG_DIR, 'hermesLogging.config')
     if not os.path.isfile(defaultLocalConfig):
-        defaultConfig = read_text('hermes.utils.logging', 'hermesLogging.config')
+        defaultConfig = files('hermes.utils.logging').joinpath('hermesLogging.config').read_text()
         with open(defaultLocalConfig,'w') as localConfig:
             localConfig.write(defaultConfig)
 


### PR DESCRIPTION
## Summary
Fixes two DeprecationWarnings that surface in hera's CI test output (hera clones this repo into `_vendor/hermes`):

- `hermes/utils/logging/helpers.py`: replaced deprecated `importlib.resources.read_text` with `files().joinpath().read_text()`.
- `hermes/taskwrapper/wrapper.py`: `parsePath`'s docstring documents the `\{ \}` escape syntax; made it a raw string (`r"""`) so the backslash is literal instead of triggering an invalid-escape-sequence warning.

Refs KaplanOpenSource/hera#971

## Test plan
- [x] Compiled both files with `DeprecationWarning`/`SyntaxWarning` promoted to errors — no warnings
- [ ] Confirm hera's CI no longer reports these two warnings once this merges and hera's CI re-clones `_vendor/hermes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)